### PR TITLE
Fix linux-exports workflow

### DIFF
--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -70,12 +70,12 @@ jobs:
       # Open Editor to import assets
       - name: Open Rebel Engine Editor
         run: |
-          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} -e -q 2>&1 | tee editor.log || true
+          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} -e -q 2>&1 | tee editor.log
           ./check_log.py editor.log
 
       - name: Run Rebel Engine Test Project
         run: |
-          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} 300 2>&1 | tee project.log || true
+          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} 300 2>&1 | tee project.log
           ./check_log.py project.log
 
       - name: Upload artifacts

--- a/.github/workflows/linux-exports.yml
+++ b/.github/workflows/linux-exports.yml
@@ -19,7 +19,7 @@ jobs:
             engine-build-options: use_asan=yes use_ubsan=yes use_llvm=yes use_lld=yes
             rebel-engine: RebelEngine/bin/godot.x11.tools.64.llvms
             template-build-options: tools=no target=release debug_symbols=yes use_asan=yes use_ubsan=yes use_llvm=yes use_lld=yes
-            template: RebleEngine/bin/godot.x11.opt.64.llvms
+            template: RebelEngine/bin/godot.x11.opt.64.llvms
             export-preset: Linux/X11
             export-preset-key: LINUX_DEBUG_TEMPLATE
             project: linux-debug-project
@@ -65,12 +65,12 @@ jobs:
         run: |
           template="$(pwd)/${{ matrix.template }}"
           sed -i "s|${{ matrix.export-preset-key }}|$template|" export_presets.cfg
-          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} --export-debug "${{ matrix.export-preset }}" ${{ matrix.project }} 2>&1 | tee export.log || true
+          DRI_PRIME=0 xvfb-run ${{ matrix.rebel-engine }} --export-debug "${{ matrix.export-preset }}" ${{ matrix.project }} 2>&1 | tee export.log
           ./check_log.py export.log
 
       - name: Run Linux Export Project
         run: |
-          DRI_PRIME=0 xvfb-run linux-debug-project 300 2>&1 | tee project.log || true
+          DRI_PRIME=0 xvfb-run ./${{ matrix.project }} 300 2>&1 | tee project.log
           ./check_log.py project.log
 
       - name: Upload artifacts


### PR DESCRIPTION
The Linux exports CI test isn't currently running properly, but the CI test passes, because the error codes returned by Rebel Engine are being ignored with `|| true`. So, when Rebel Engine fails to run, this too is being ignored.

This PR updates the workflows to fail if Rebel Engine fails to run or returns an error code. It also fixes a typo in the folder name, defines the path when running the exported project that's now located in the working directory and uses the matrix variable name for running the exported project.
