### PR TITLE
Only use build cache from the same matrix job

### DIFF
--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -56,8 +56,7 @@ jobs:
           path: RebelEngine/${{ env.SCONS_CACHE }}
           key: ${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
           restore-keys: |
-            ${{ github.job }}-${{ strategy.job-index }}
-            ${{ github.job }}-
+            ${{ github.job }}-${{ strategy.job-index }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux-exports.yml
+++ b/.github/workflows/linux-exports.yml
@@ -46,8 +46,7 @@ jobs:
           path: RebelEngine/${{ env.SCONS_CACHE }}
           key: ${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
           restore-keys: |
-            ${{ github.job }}-${{ strategy.job-index }}
-            ${{ github.job }}-
+            ${{ github.job }}-${{ strategy.job-index }}-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Currently, when there is a build cache miss, and a matrix job doesn't have a previous cache, it uses any cache from the workflow job. This cache generally will contain useless build files. These useless build files are retained when the new cache is saved i.e. results in an unnecessarily larger cache.

This PR changes the alternative restore keys to only use a cache associated with the matrix job. If none exists, a new cache is created. To ensure that old caches with useless build files are not retained, this PR requires deleting all the existing caches; so that new caches can be created.

**Note:** Since the matrix job is identified through an index number, if a matrix job is inserted, instead of appended, the caches will need to be deleted too.