### PR TITLE
Fix issues with new action

### DIFF
--- a/.github/actions/build-rebel/action.yaml
+++ b/.github/actions/build-rebel/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: RebelEngine/${{ env.SCONS_CACHE }}
-        key: ${{ github.job }}-${{ strategy.job-index }}-${{ github.ref_name }}
+        key: ${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
         restore-keys: |
           ${{ github.job }}-${{ strategy.job-index }}-
 
@@ -64,7 +64,7 @@ runs:
         #Build Rebel
         echo "::group::Build Rebel"
         scons -j2 ${{ inputs.build-options }}
-        echo "::ungroup::"
+        echo "::endgroup::"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes two minor issues with the new Rebel build action:
- Uses the commit hash instead of branch name when creating the cache. This allows a new cache to be created every time the branch is updated.
- Properly closes the build output grouping for the build step.