### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/linux-tests.yaml
+++ b/.github/workflows/linux-tests.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Build Rebel
-        uses: RebelToolbox/RebelBuildAction@v1
+        uses: RebelToolbox/RebelBuildAction@v2
         with:
           artifact: ${{ matrix.artifact }}
           build-options: ${{ matrix.build-options }}
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout Rebel Test Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.artifact }}
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}-logs
           path: |
@@ -122,15 +122,15 @@ jobs:
 
     steps:
       - name: Checkout Rebel Test Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Editor Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.editor-artifact }}
 
       - name: Download Template Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.template-artifact }}
 
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.export }}
           path: |


### PR DESCRIPTION
The end-of-life date for Node.js 16 was brought forward by seven months to coincide with the end of support of OpenSSL 1.1.1 on 11th September 2023.[[1](https://nodejs.org/en/blog/announcements/nodejs16-eol/)]. This prompted GitHub to initiate the deprecation process for GitHub Actions using Node.js 16 and transition all actions to run on Node 20 by Spring 2024.[[2](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)].

This PR upgrades the GitHub workflow's actions to use the latest versions:
- [RebelToolbox/RebelBuildAction](https://github.com/RebelToolbox/RebelBuildAction): v2
- [actions/checkout](https://github.com/actions/checkout): v4
- [actions/download-artifact](https://github.com/actions/download-artifact): v4
- [actions/upload-artifact](https://github.com/actions/upload-artifact): v4

[1] https://nodejs.org/en/blog/announcements/nodejs16-eol/
[2] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/