### PR TITLE
Update weekly tests to use the latest version of Ubuntu

### DIFF
--- a/.github/workflows/linux-tests.yaml
+++ b/.github/workflows/linux-tests.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   linux-builds:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Emscripten, which is used to build Rebel for the Web, is not included in Ubuntu 20.04.

[Rebel Build Action](https://github.com/RebelToolbox/RebelBuildAction) has been updated to include web builds, but it currently relies on Emscripten being available in the the Ubuntu repository.

This PR updates the weekly tests to use the latest Ubuntu long-term support version (currently 22.04) which does include Emscripten. 