### PR TITLE
Update tests build filename

### DIFF
--- a/.github/workflows/linux-tests.yaml
+++ b/.github/workflows/linux-tests.yaml
@@ -20,27 +20,27 @@ jobs:
           - name: Build production editor
             artifact: linux-editor
             build-options: production=yes
-            rebel-executable: rebel.x11.tools.64
+            rebel-executable: rebel.linux.tools.64
 
           - name: Build with Clang address (includes leak) and undefined bahaviour sanitizers
             artifact: clang-asan-ubsan-sanitizers
             build-options: use_asan=yes use_ubsan=yes use_llvm=yes use_lld=yes
-            rebel-executable: rebel.x11.tools.64.llvms
+            rebel-executable: rebel.linux.tools.64.llvms
 
           - name: Build with Clang thread sanitizer
             artifact: clang-tsan-sanitizer
             build-options: use_tsan=yes use_llvm=yes use_lld=yes
-            rebel-executable: rebel.x11.tools.64.llvms
+            rebel-executable: rebel.linux.tools.64.llvms
 
           - name: Build with GCC address (includes leak) and undefined behaviour sanitizers
             artifact: gcc-asan-ubsan-sanitizers
             build-options: use_asan=yes use_ubsan=yes
-            rebel-executable: rebel.x11.tools.64s
+            rebel-executable: rebel.linux.tools.64s
 
           - name: Build Linux Debug Template with Clang address (includes leak) and undefined behaviour sanitizers
             artifact: linux-debug-template
             build-options: tools=no target=release debug_symbols=yes use_asan=yes use_ubsan=yes use_llvm=yes use_lld=yes
-            rebel-executable: rebel.x11.opt.64.llvms
+            rebel-executable: rebel.linux.opt.64.llvms
 
     steps:
       - name: Build Rebel
@@ -60,15 +60,15 @@ jobs:
         include:
           - name: Test Clang address (includes leak) and undefined bahaviour sanitizers
             artifact: clang-asan-ubsan-sanitizers
-            rebel-executable: rebel.x11.tools.64.llvms
+            rebel-executable: rebel.linux.tools.64.llvms
 
           - name: Test Clang thread sanitizer
             artifact: clang-tsan-sanitizer
-            rebel-executable: rebel.x11.tools.64.llvms
+            rebel-executable: rebel.linux.tools.64.llvms
 
           - name: Test GCC address (includes leak) and undefined bahaviour sanitizers
             artifact: gcc-asan-ubsan-sanitizers
-            rebel-executable: rebel.x11.tools.64s
+            rebel-executable: rebel.linux.tools.64s
 
     steps:
       - name: Checkout Rebel Test Project
@@ -112,9 +112,9 @@ jobs:
         include:
           - name: Test Exported Linux Rebel Project
             editor-artifact: linux-editor
-            editor: rebel.x11.tools.64
+            editor: rebel.linux.tools.64
             template-artifact: linux-debug-template
-            template: rebel.x11.opt.64.llvms
+            template: rebel.linux.opt.64.llvms
             export-preset: Linux/X11
             export-preset-key: LINUX_DEBUG_TEMPLATE
             export-type: -debug


### PR DESCRIPTION
RebelToolbox/RebelEngine#80 renamed the platforms to better reflect their names, this PR updates the Test Project's test scripts to use the new platform names.